### PR TITLE
Call functions inside module with module.exports

### DIFF
--- a/src/personnummer.js
+++ b/src/personnummer.js
@@ -107,7 +107,7 @@ const getParts = (ssn) => {
  * @return {string}
  */
 module.exports.format = (ssn, longFormat) => {
-  if (!this.valid(ssn)) {
+  if (!module.exports.valid(ssn)) {
     return '';
   }
 
@@ -168,7 +168,7 @@ module.exports.getAge = (ssn, includeCoordinationNumber) => {
     includeCoordinationNumber = true;
   }
 
-  if (!this.valid(ssn, includeCoordinationNumber)) {
+  if (!module.exports.valid(ssn, includeCoordinationNumber)) {
     return 0;
   }
 


### PR DESCRIPTION
When I use personnummer.format() it throws a `TypeError: Cannot read property 'valid' of undefined` error. I'm not sure why but I suspect is has to do with the scope not being correct. With these code changes it seems to work.
The unit tests also run ok.