### PR TITLE
Set the right separator to match the full year

### DIFF
--- a/src/personnummer.js
+++ b/src/personnummer.js
@@ -76,21 +76,17 @@ const getParts = (ssn) => {
     century = ('' + (baseYear - ((baseYear - year) % 100))).substr(0, 2);
   }
 
-  if (sep !== '-' && sep !== '+') {
-    if ((new Date).getFullYear() - parseInt(century + year, 10) < 100) {
-      sep = '-';
-    } else {
-      sep = '+';
-    }
-  } else {
-    // Set the right separator to match the full year.
-    // >= 100 should use + and < 100 should use -
-    const yearDiff = (new Date().getFullYear()) - parseInt(century + year, 10);
-    if (sep === '-' && yearDiff >= 100) {
-      sep = '+';
-    } else if (sep === '+' && yearDiff < 100) {
-      sep = '-';
-    }
+  if (!sep) {
+    sep = '-';
+  }
+
+  // Set the right separator to match the full year.
+  // >= 100 should use + and < 100 should use -
+  const yearDiff = (new Date().getFullYear()) - parseInt(century + year, 10);
+  if (sep === '-' && yearDiff >= 100) {
+    sep = '+';
+  } else if (sep === '+' && yearDiff < 100) {
+    sep = '-';
   }
 
   return {

--- a/src/personnummer.js
+++ b/src/personnummer.js
@@ -63,14 +63,6 @@ const getParts = (ssn) => {
   let num = match[6];
   let check = match[7];
 
-  if (sep !== '-' && sep !== '+') {
-    if ((typeof century === 'undefined' || !century.length) || (new Date).getFullYear() - parseInt(century + year, 10) < 100) {
-      sep = '-';
-    } else {
-      sep = '+';
-    }
-  }
-
   if (typeof century === 'undefined' || !century.length) {
     const d = new Date;
     let baseYear = 0;
@@ -82,6 +74,23 @@ const getParts = (ssn) => {
     }
 
     century = ('' + (baseYear - ((baseYear - year) % 100))).substr(0, 2);
+  }
+
+  if (sep !== '-' && sep !== '+') {
+    if ((typeof century === 'undefined' || !century.length) || (new Date).getFullYear() - parseInt(century + year, 10) < 100) {
+      sep = '-';
+    } else {
+      sep = '+';
+    }
+  } else {
+    // Set the right separator to match the full year.
+    // >= 100 should use + and < 100 should use -
+    const yearDiff = (new Date().getFullYear()) - parseInt(century + year);
+    if (sep === '-' && yearDiff >= 100) {
+      sep = '+';
+    } else if (sep === '+' && yearDiff < 100) {
+      sep = '-';
+    }
   }
 
   return {

--- a/src/personnummer.js
+++ b/src/personnummer.js
@@ -77,7 +77,7 @@ const getParts = (ssn) => {
   }
 
   if (sep !== '-' && sep !== '+') {
-    if ((typeof century === 'undefined' || !century.length) || (new Date).getFullYear() - parseInt(century + year, 10) < 100) {
+    if ((new Date).getFullYear() - parseInt(century + year, 10) < 100) {
       sep = '-';
     } else {
       sep = '+';

--- a/src/personnummer.js
+++ b/src/personnummer.js
@@ -85,7 +85,7 @@ const getParts = (ssn) => {
   } else {
     // Set the right separator to match the full year.
     // >= 100 should use + and < 100 should use -
-    const yearDiff = (new Date().getFullYear()) - parseInt(century + year);
+    const yearDiff = (new Date().getFullYear()) - parseInt(century + year, 10);
     if (sep === '-' && yearDiff >= 100) {
       sep = '+';
     } else if (sep === '+' && yearDiff < 100) {

--- a/test.js
+++ b/test.js
@@ -79,6 +79,8 @@ test('should format input valus as personnummer', t => {
   t.is('190001010107', personnummer.format('000101+0107', true));
   t.is('130401+2931', personnummer.format('19130401-2931'));
   t.is('900101-0017', personnummer.format('19900101+0017'));
+  t.is('121212+1212', personnummer.format('19121212-1212'));
+  t.is('121212-1212', personnummer.format('20121212+1212'));
 });
 
 test('should not format input value as personnummer', t => {

--- a/test.js
+++ b/test.js
@@ -60,7 +60,7 @@ test('should not validate wrong co-ordination numbers', t => {
   t.is(false, personnummer.valid('640893-3231'));
 });
 
-test('should format input valus as personnummer', t => {
+test('should format input values as personnummer', t => {
   t.is('640327-3813', personnummer.format(6403273813));
   t.is('510818-9167', personnummer.format('510818-9167'));
   t.is('900101-0017', personnummer.format('19900101-0017'));
@@ -77,6 +77,9 @@ test('should format input valus as personnummer', t => {
   t.is('200001010107', personnummer.format('0001010107', true));
   t.is('200001010107', personnummer.format('000101-0107', true));
   t.is('190001010107', personnummer.format('000101+0107', true));
+});
+
+test('should format input values and replace separator with the right one', t => {
   t.is('130401+2931', personnummer.format('19130401-2931'));
   t.is('900101-0017', personnummer.format('19900101+0017'));
   t.is('121212+1212', personnummer.format('19121212-1212'));

--- a/test.js
+++ b/test.js
@@ -61,22 +61,24 @@ test('should not validate wrong co-ordination numbers', t => {
 });
 
 test('should format input valus as personnummer', t => {
-  t.is('640327-3813', personnummer.format(6403273813))
-  t.is('510818-9167', personnummer.format('510818-9167'))
-  t.is('900101-0017', personnummer.format('19900101-0017'))
-  t.is('130401+2931', personnummer.format('19130401+2931'))
-  t.is('640823-3234', personnummer.format('196408233234'))
-  t.is('000101-0107', personnummer.format('0001010107'))
-  t.is('000101-0107', personnummer.format('000101-0107'))
-  t.is('130401+2931', personnummer.format('191304012931'))
-  t.is('196403273813', personnummer.format(6403273813, true))
-  t.is('195108189167', personnummer.format('510818-9167', true))
-  t.is('199001010017', personnummer.format('19900101-0017', true))
-  t.is('191304012931', personnummer.format('19130401+2931', true))
-  t.is('196408233234', personnummer.format('196408233234', true))
-  t.is('200001010107', personnummer.format('0001010107', true))
-  t.is('200001010107', personnummer.format('000101-0107', true))
-  t.is('190001010107', personnummer.format('000101+0107', true))
+  t.is('640327-3813', personnummer.format(6403273813));
+  t.is('510818-9167', personnummer.format('510818-9167'));
+  t.is('900101-0017', personnummer.format('19900101-0017'));
+  t.is('130401+2931', personnummer.format('19130401+2931'));
+  t.is('640823-3234', personnummer.format('196408233234'));
+  t.is('000101-0107', personnummer.format('0001010107'));
+  t.is('000101-0107', personnummer.format('000101-0107'));
+  t.is('130401+2931', personnummer.format('191304012931'));
+  t.is('196403273813', personnummer.format(6403273813, true));
+  t.is('195108189167', personnummer.format('510818-9167', true));
+  t.is('199001010017', personnummer.format('19900101-0017', true));
+  t.is('191304012931', personnummer.format('19130401+2931', true));
+  t.is('196408233234', personnummer.format('196408233234', true));
+  t.is('200001010107', personnummer.format('0001010107', true));
+  t.is('200001010107', personnummer.format('000101-0107', true));
+  t.is('190001010107', personnummer.format('000101+0107', true));
+  t.is('130401+2931', personnummer.format('19130401-2931'));
+  t.is('900101-0017', personnummer.format('19900101+0017'));
 });
 
 test('should not format input value as personnummer', t => {


### PR DESCRIPTION
This will fix so the right separator is used. See https://github.com/personnummer/meta/issues/18