### PR TITLE
fix invalid parsing of shortform personal identity numbers for people over 100

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,7 @@ class Personnummer {
       let baseYear = 0;
 
       if (sep === '+') {
+        this._sep = '+';
         baseYear = d.getFullYear() - 100;
       } else {
         this._sep = '-';
@@ -222,7 +223,7 @@ class Personnummer {
     }
 
     this._year = year;
-    this._fullYear = century + year;
+    this._fullYear = this._century + year;
     this._month = month;
     this._day = day;
     this._num = num;


### PR DESCRIPTION
Set `this._sep` when parsing shortformat of a person older than 100.
Use `this._century` for calculating `this.fullYear`

fixes #60

**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update