### PR TITLE
fix: if ageDay is 9 the prefixing zero is left out.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -292,7 +292,7 @@ class Personnummer {
       '-' +
       this.month +
       '-' +
-      (ageDay < 9 ? '0' + ageDay : ageDay);
+      (ageDay <= 9 ? '0' + ageDay : ageDay);
 
     return diffInYears(new Date(Date.now()), new Date(ageDate));
   }


### PR DESCRIPTION
**Type of change**
- [x] Bug fix


**Description**

Fixes a bug if ageDay is exactly 9

**Related issue**
https://github.com/personnummer/js/issues/206

