### PR TITLE
New format types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10248,8 +10248,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -12800,8 +12799,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,3 +3,9 @@ export class PersonnummerError extends Error {
     super('Invalid swedish personal identity number');
   }
 }
+
+export class PersonnumerFormatError extends Error {
+  constructor() {
+    super('Invalid format type');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,18 +278,18 @@ class Personnummer {
     // To support older version of this function
     if (typeof type === "boolean") {
       // This function used to take a boolean as an input and
-      return this.format(type ? "long" : "short");
+      return this.format(type ? "long" : "separatedShort");
     }
 
     switch (type) {
       case "long":
         return `${this.century}${this.year}${this.month}${this.day}${this.num}${this.check}`;
       case "short":
-        return `${this.year}${this.month}${this.day}${this.sep}${this.num}${this.check}`;
+        return `${this.year}${this.month}${this.day}${this.num}${this.check}`;
       case "separatedLong":
-        return `${this.century}${this.year}${this.month}${this.day}${this.getAge() >= 100 ? "+" : "-"}${this.num}${this.check}`;
+        return `${this.century}${this.year}${this.month}${this.day}${this.sep}${this.num}${this.check}`;
       case "separatedShort":
-        return `${this.year}${this.month}${this.day}${this.getAge() >= 100 ? "+" : "-"}${this.num}${this.check}`;
+        return `${this.year}${this.month}${this.day}${this.sep}${this.num}${this.check}`;
     }
 
     // Falltrough case if someone uses JavaScript instead of TypeScript.

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ class Personnummer {
    */
   // eslint-disable-next-line
   private parse(ssn: string, options?: OptionsType) {
-    const reg = /^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([+-]?)((?!000)\d{3})(\d)$/;
+    const reg = /^(\d{2})?(\d{2})(\d{2})(\d{2})([+-]?)((?!000)\d{3})(\d)$/;
     const match = reg.exec(ssn);
 
     if (!match) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,16 @@
-import { PersonnummerError } from './errors';
+import { PersonnumerFormatError, PersonnummerError } from './errors';
 import { diffInYears, luhn, testDate } from './utils';
 
 type OptionsType = {
   [key: string]: boolean | number | string;
 };
+
+type FormatTypes =
+  "long" |
+  "short" |
+  "separatedShort" |
+  "separatedLong"
+
 
 class Personnummer {
   /**
@@ -166,7 +173,7 @@ class Personnummer {
    */
   static valid(ssn: string, options?: OptionsType): boolean {
     try {
-      Personnummer.parse(ssn, options);
+      new Personnummer(ssn, options);
       return true;
     } catch (e) {
       return false;
@@ -263,16 +270,30 @@ class Personnummer {
    *
    * If the input number could not be parsed a empty string will be returned.
    *
-   * @param {boolean} longFormat
+   * @param {string} type
    *
    * @return {string}
    */
-  format(longFormat = false): string {
-    if (longFormat) {
-      return `${this.century}${this.year}${this.month}${this.day}${this.num}${this.check}`;
+  format(type: boolean | FormatTypes = false): string {
+    // To support older version of this function
+    if (typeof type === "boolean") {
+      // This function used to take a boolean as an input and
+      return this.format(type ? "long" : "short");
     }
 
-    return `${this.year}${this.month}${this.day}${this.sep}${this.num}${this.check}`;
+    switch (type) {
+      case "long":
+        return `${this.century}${this.year}${this.month}${this.day}${this.num}${this.check}`;
+      case "short":
+        return `${this.year}${this.month}${this.day}${this.sep}${this.num}${this.check}`;
+      case "separatedLong":
+        return `${this.century}${this.year}${this.month}${this.day}${this.getAge() >= 100 ? "+" : "-"}${this.num}${this.check}`;
+      case "separatedShort":
+        return `${this.year}${this.month}${this.day}${this.getAge() >= 100 ? "+" : "-"}${this.num}${this.check}`;
+    }
+
+    // Falltrough case if someone uses JavaScript instead of TypeScript.
+    throw new PersonnumerFormatError();
   }
 
   /**

--- a/test.ts
+++ b/test.ts
@@ -45,12 +45,29 @@ test('should format personnummer', async () => {
 
     availableListFormats.forEach((format) => {
       if (format !== 'short_format') {
+        // Old version
         expect(Personnummer.parse(item[format]).format()).toBe(
           item.separated_format
         );
         expect(Personnummer.parse(item[format]).format(true)).toBe(
           item.long_format
         );
+
+
+        // New version
+        expect(Personnummer.parse(item[format]).format("long")).toBe(
+          item.long_format
+        );
+        expect(Personnummer.parse(item[format]).format("short")).toBe(
+          item.short_format
+        );
+        expect(Personnummer.parse(item[format]).format("separatedShort")).toBe(
+          item.separated_format
+        );
+        expect(Personnummer.parse(item[format]).format("separatedLong")).toBe(
+          item.separated_long
+        );
+
       }
     });
   });


### PR DESCRIPTION
## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

## Description
Adds two new ways to format personnummer:

Now there are four versions to format a personnummer:
- **short**: 4103219202
- **long**: 194103219202
- **separatedShort**: 410321-9202
- **separatedLong**: 19410321-9202

I've also made sure to support the old version to call the format function. It can still be called with a boolean and you will get the same format as the function would give before this change.

## Motivation
I needed to format a personnummer in a different way than the two previous ways to format. There are 4 different common formats I see on personnummer and this package only supports two of them.

## Considerations
the function right now takes a string as an argument `Personnummer.parse("194103219202").format("separatedLong")`. This might be better achieved with an enum or a separate "format class" which has a method to handle formatting.

## Checklist
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
- [x] New tests added which covers the added code.
- [x] Documentation is updated.
- [ ] This PR includes breaking changes.

**I couldn't find any CONTRIBUTING document or style lints / documentation. I selected them because I'm worried I would get automatically rejected otherwise. It seems like those features / documents doesn't exist? Is this just a standard PR template?**