### PR TITLE
Feature: Swedish Personal Identity number date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -281,8 +281,8 @@ class Personnummer {
    * @return {number}
    */
   getAge(): number {
-    const dateOfBirth = this.getDate();
-    return diffInYears(new Date(Date.now()), dateOfBirth);
+    const date = this.getDate();
+    return diffInYears(new Date(Date.now()), date);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,6 +281,14 @@ class Personnummer {
    * @return {number}
    */
   getAge(): number {
+    const dateOfBirth = this.getDateOfBirth();
+    return diffInYears(new Date(Date.now()), dateOfBirth);
+  }
+
+  /**
+   * Get date of birth from a Swedish personal identity number.
+   */
+  getDateOfBirth(): Date {
     let ageDay = +this.day;
     if (this.isCoordinationNumber()) {
       ageDay -= 60;
@@ -294,7 +302,7 @@ class Personnummer {
       '-' +
       (ageDay < 10 ? '0' + ageDay : ageDay);
 
-    return diffInYears(new Date(Date.now()), new Date(ageDate));
+    return new Date(ageDate);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,14 +281,14 @@ class Personnummer {
    * @return {number}
    */
   getAge(): number {
-    const dateOfBirth = this.getDateOfBirth();
+    const dateOfBirth = this.getDate();
     return diffInYears(new Date(Date.now()), dateOfBirth);
   }
 
   /**
-   * Get date of birth from a Swedish personal identity number.
+   * Get date from a Swedish personal identity number.
    */
-  getDateOfBirth(): Date {
+  getDate(): Date {
     let ageDay = +this.day;
     if (this.isCoordinationNumber()) {
       ageDay -= 60;

--- a/test.ts
+++ b/test.ts
@@ -150,7 +150,7 @@ it('should test personnummer age', async () => {
   });
 });
 
-it('should test personnummer date of birth', async () => {
+it('should test personnummer date', async () => {
   const list = await testList();
 
   list.forEach((item) => {
@@ -167,12 +167,12 @@ it('should test personnummer date of birth', async () => {
     }
 
     const ageDate = `${year}-${month}-${day}`;
-    const dateOfBirth = new Date(ageDate);
+    const personnummerDate = new Date(ageDate);
 
     availableListFormats.forEach((format) => {
       if (format !== 'short_format') {
-        expect(Personnummer.parse(item[format]).getDateOfBirth()).toStrictEqual(
-          dateOfBirth
+        expect(Personnummer.parse(item[format]).getDate()).toStrictEqual(
+          personnummerDate
         );
       }
     });

--- a/test.ts
+++ b/test.ts
@@ -150,6 +150,35 @@ it('should test personnummer age', async () => {
   });
 });
 
+it('should test personnummer date of birth', async () => {
+  const list = await testList();
+
+  list.forEach((item) => {
+    if (!item.valid) {
+      return;
+    }
+
+    const pin = item.separated_long;
+    const year = pin.slice(0, 4);
+    const month = pin.slice(4, 6);
+    let day = pin.slice(6, 8);
+    if (item.type == 'con') {
+      day = '' + (parseInt(day) - 60);
+    }
+
+    const ageDate = `${year}-${month}-${day}`;
+    const dateOfBirth = new Date(ageDate);
+
+    availableListFormats.forEach((format) => {
+      if (format !== 'short_format') {
+        expect(Personnummer.parse(item[format]).getDateOfBirth()).toStrictEqual(
+          dateOfBirth
+        );
+      }
+    });
+  });
+});
+
 it('should test organization numbers and throw error', async () => {
   const list = await testList('orgnumber');
 


### PR DESCRIPTION
**Type of change**

- [x] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

I have been using this api in other projects and found that as a consumer I end up doing things like this:

```typescript
const pnr = Personnummer.parse(personalIdentityNumber);

const { fullYear: year, month, day: dayString } = pnr;

let day = parseInt(dayString, 10);
if (pnr.isCoordinationNumber()) {
  day = day - 60;
}

const birthDate = new Date(`${year}-${month}-${day}`);
```

With the goal of getting a date and then working with the date to get diffs in different units, such as months, days or years. With `getAge` that already exists I lose some granularity such as months. I went ahead and made a suggestion for this using the code in `getAge` to avoid breaking things.

**Related issue**
None

**Motivation**

It would be great to able to have a `Date` to work with to integrate nicely with other libs such as `date-fns` and getting `differenceInMonths` or other units. And also avoiding having to know about coordination numbers in my consuming code. In my example I have to check if the personal identity number is a coordination number to figure out the date of birth.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [ ] Style lints passes.
- [ ] Documentation of new public methods exists.
- [x] New tests added which covers the added code.
- [ ] Documentation is updated.
- [ ] This PR includes breaking changes.
